### PR TITLE
Load theme setup earlier

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -153,4 +153,4 @@ require get_theme_file_path( '/inc/includes.php' );
 require get_theme_file_path( '/inc/template-tags.php' );
 
 // Run theme setup
-theme_setup();
+add_action( 'init', __NAMESPACE__ . '\theme_setup' );


### PR DESCRIPTION
CPT:s can't be registered to use default taxonomies if they aren't registered in the init stage.