### PR TITLE
Simplify default accessibility string translations handling

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -6,14 +6,21 @@
  *
  * @Author: Roni Laukkarinen
  * @Date: 2020-05-11 13:33:49
- * @Last Modified by: Roni Laukkarinen
- * @Last Modified time: 2020-05-11 13:33:49
+ * @Last Modified by:   Timi Wahalahti
+ * @Last Modified time: 2020-11-19 09:59:56
  *
  * @link https://developer.wordpress.org/themes/basics/template-files/#template-partials
  * @package air-light
  */
 
 namespace Air_Light;
+
+// Reminder for translated accessible labels
+if ( function_exists( 'pll_the_languages' ) && function_exists( 'ask_e' ) ) {
+  $screenreadertext_top = ask__( 'Accessibility: Back to top' );
+} else {
+  $screenreadertext_top = 'Back to top';
+}
 
 ?>
 
@@ -22,15 +29,6 @@ namespace Air_Light;
 <footer id="colophon" class="block block-footer site-footer">
 
   <?php get_template_part( 'template-parts/footer/demo-content' ); ?>
-
-  <?php
-    // Reminder for translated accessible labels
-    if ( function_exists( 'pll_the_languages' ) && function_exists( 'ask_e' ) ) {
-      $screenreadertext_top = ask__( 'Accessibility: Back to top' );
-    } else {
-      $screenreadertext_top = 'Back to top';
-    }
-  ?>
 
   <p class="back-to-top"><a href="#page" class="js-trigger top no-text-link no-external-link-indicator" data-mt-duration="300"><span class="screen-reader-text"><?php echo esc_html( $screenreadertext_top ); ?></span><?php include get_theme_file_path( '/svg/chevron-up.svg' ); ?></a></p>
 

--- a/footer.php
+++ b/footer.php
@@ -7,20 +7,13 @@
  * @Author: Roni Laukkarinen
  * @Date: 2020-05-11 13:33:49
  * @Last Modified by:   Timi Wahalahti
- * @Last Modified time: 2020-11-19 09:59:56
+ * @Last Modified time: 2020-11-19 11:24:01
  *
  * @link https://developer.wordpress.org/themes/basics/template-files/#template-partials
  * @package air-light
  */
 
 namespace Air_Light;
-
-// Reminder for translated accessible labels
-if ( function_exists( 'pll_the_languages' ) && function_exists( 'ask_e' ) ) {
-  $screenreadertext_top = ask__( 'Accessibility: Back to top' );
-} else {
-  $screenreadertext_top = 'Back to top';
-}
 
 ?>
 
@@ -30,7 +23,7 @@ if ( function_exists( 'pll_the_languages' ) && function_exists( 'ask_e' ) ) {
 
   <?php get_template_part( 'template-parts/footer/demo-content' ); ?>
 
-  <p class="back-to-top"><a href="#page" class="js-trigger top no-text-link no-external-link-indicator" data-mt-duration="300"><span class="screen-reader-text"><?php echo esc_html( $screenreadertext_top ); ?></span><?php include get_theme_file_path( '/svg/chevron-up.svg' ); ?></a></p>
+  <p class="back-to-top"><a href="#page" class="js-trigger top no-text-link no-external-link-indicator" data-mt-duration="300"><span class="screen-reader-text"><?php echo esc_html( get_default_localization( 'Back to top' ) ); ?></span><?php include get_theme_file_path( '/svg/chevron-up.svg' ); ?></a></p>
 
 </footer><!-- #colophon -->
 

--- a/header.php
+++ b/header.php
@@ -6,13 +6,20 @@
  *
  * @Author: Roni Laukkarinen
  * @Date: 2020-05-11 13:17:32
- * @Last Modified by: Roni Laukkarinen
- * @Last Modified time: 2020-05-11 13:17:32
+ * @Last Modified by:   Timi Wahalahti
+ * @Last Modified time: 2020-11-19 10:00:12
  *
  * @package air-light
  */
 
 namespace Air_Light;
+
+// Reminder for translated accessible labels
+if ( function_exists( 'pll_the_languages' ) && function_exists( 'ask_e' ) ) {
+  $screenreadertext_skip = ask__( 'Accessibility: Skip to content' );
+} else {
+  $screenreadertext_skip = 'Skip to content';
+}
 
 ?>
 <!doctype html>
@@ -29,15 +36,6 @@ namespace Air_Light;
 <body <?php body_class( 'no-js' ); ?>>
   <?php wp_body_open(); ?>
   <div id="page" class="site">
-
-  <?php
-    // Reminder for translated accessible labels
-    if ( function_exists( 'pll_the_languages' ) && function_exists( 'ask_e' ) ) {
-      $screenreadertext_skip = ask__( 'Accessibility: Skip to content' );
-    } else {
-      $screenreadertext_skip = 'Skip to content';
-    }
-  ?>
 
     <a class="skip-link screen-reader-text" href="#content"><?php echo esc_html( $screenreadertext_skip ); ?></a>
 

--- a/header.php
+++ b/header.php
@@ -7,21 +7,15 @@
  * @Author: Roni Laukkarinen
  * @Date: 2020-05-11 13:17:32
  * @Last Modified by:   Timi Wahalahti
- * @Last Modified time: 2020-11-19 10:00:12
+ * @Last Modified time: 2020-11-19 11:24:53
  *
  * @package air-light
  */
 
 namespace Air_Light;
 
-// Reminder for translated accessible labels
-if ( function_exists( 'pll_the_languages' ) && function_exists( 'ask_e' ) ) {
-  $screenreadertext_skip = ask__( 'Accessibility: Skip to content' );
-} else {
-  $screenreadertext_skip = 'Skip to content';
-}
-
 ?>
+
 <!doctype html>
 <html <?php language_attributes(); ?>>
 
@@ -37,7 +31,7 @@ if ( function_exists( 'pll_the_languages' ) && function_exists( 'ask_e' ) ) {
   <?php wp_body_open(); ?>
   <div id="page" class="site">
 
-    <a class="skip-link screen-reader-text" href="#content"><?php echo esc_html( $screenreadertext_skip ); ?></a>
+    <a class="skip-link screen-reader-text" href="#content"><?php echo esc_html( get_default_localization( 'Skip to content' ) ); ?></a>
 
     <div class="nav-container">
       <header class="site-header">

--- a/inc/hooks.php
+++ b/inc/hooks.php
@@ -18,11 +18,6 @@ namespace Air_Light;
 // require get_theme_file_path( 'inc/hooks/breadcrumb.php' );
 
 /**
- * Localized strings (Polylang Pro + Air Helper)
- */
-require get_theme_file_path( '/inc/includes/localization.php' );
-
-/**
  * Ensure HTML validation and cleanups
  */
 require get_theme_file_path( '/inc/includes/cleanups.php' );

--- a/inc/hooks/scripts-styles.php
+++ b/inc/hooks/scripts-styles.php
@@ -5,8 +5,8 @@
  * @package air-light
  * @Author: Niku Hietanen
  * @Date: 2020-02-20 13:46:50
- * @Last Modified by: Niku Hietanen
- * @Last Modified time: 2020-10-02 11:08:21
+ * @Last Modified by:   Timi Wahalahti
+ * @Last Modified time: 2020-11-19 10:34:28
  */
 
 namespace Air_Light;
@@ -44,58 +44,15 @@ function enqueue_theme_scripts() {
     wp_enqueue_script( 'comment-reply' );
   }
 
-  // Reminder for translated accessible labels
-  if ( function_exists( 'pll_the_languages' ) && function_exists( 'ask_e' ) ) {
-    if ( 'fi' === pll_current_language() ) {
-      $screenreadertext_expand = ask__( 'Saavutettavuus: Avaa alavalikko' );
-      $screenreadertext_expand_toggle = ask__( 'Saavutettavuus: Avaa päävalikko' );
-      $screenreadertext_expand_for = ask__( 'Saavutettavuus: Avaa alavalikko kohteelle' );
-      $screenreadertext_collapse = ask__( 'Saavutettavuus: Sulje alavalikko' );
-      $screenreadertext_collapse_for = ask__( 'Saavutettavuus: Sulje alavalikko kohteelle' );
-      $screenreadertext_collapse_toggle = ask__( 'Saavutettavuus: Sulje päävalikko' );
-      $screenreadertext_external_link = ask__( 'Saavutettavuus: Ulkoinen sivusto:' );
-      $screenreadertext_target_blank = ask__( 'Saavutettavuus: avautuu uuteen ikkunaan' );
-    } else {
-      $screenreadertext_expand = ask__( 'Accessibility: Open child menu' );
-      $screenreadertext_expand_for = ask__( 'Accessibility: Open child menu for' );
-      $screenreadertext_expand_toggle = ask__( 'Accessibility: Open main menu' );
-      $screenreadertext_collapse = ask__( 'Accessibility: Close child menu' );
-      $screenreadertext_collapse_for = ask__( 'Accessibility: Close child menu for' );
-      $screenreadertext_collapse_toggle = ask__( 'Accessibility: Close main menu' );
-      $screenreadertext_external_link = ask__( 'Accessibility: External site:' );
-      $screenreadertext_target_blank = ask__( 'Accessibility: opens in a new window' );
-    }
-  } else {
-    if ( 'fi' === get_bloginfo( 'language' ) ) {
-      $screenreadertext_expand = esc_html__( 'Avaa alavalikko', 'air-light' );
-      $screenreadertext_expand_for = esc_html__( 'Avaa alavalikko kohteelle', 'air-light' );
-      $screenreadertext_expand_toggle = esc_html__( 'Avaa päävalikko', 'air-light' );
-      $screenreadertext_collapse = esc_html__( 'Sulje alavalikko', 'air-light' );
-      $screenreadertext_collapse_for = esc_html__( 'Sulje alavalikko kohteelle', 'air-light' );
-      $screenreadertext_collapse_toggle = esc_html__( 'Sulje päävalikko', 'air-light' );
-      $screenreadertext_external_link = esc_html__( 'Ulkoinen sivusto:', 'air-light' );
-      $screenreadertext_target_blank = esc_html__( 'avautuu uuteen ikkunaan', 'air-light' );
-    } else {
-      $screenreadertext_expand = esc_html__( 'Open child menu', 'air-light' );
-      $screenreadertext_expand_for = esc_html__( 'Open child menu for', 'air-light' );
-      $screenreadertext_expand_toggle = esc_html__( 'Open main menu', 'air-light' );
-      $screenreadertext_collapse = esc_html__( 'Close child menu', 'air-light' );
-      $screenreadertext_collapse_for = esc_html__( 'Close child menu for', 'air-light' );
-      $screenreadertext_collapse_toggle = esc_html__( 'Close main menu', 'air-light' );
-      $screenreadertext_external_link = esc_html__( 'External site:', 'air-light' );
-      $screenreadertext_target_blank = esc_html__( 'opens in a new window', 'air-light' );
-    }
-  }
-
   wp_localize_script( 'scripts', 'air_light_screenReaderText', array(
-    'expand'   => $screenreadertext_expand,
-    'collapse' => $screenreadertext_collapse,
-    'expand_for'   => $screenreadertext_expand_for,
-    'collapse_for' => $screenreadertext_collapse_for,
-    'expand_toggle'   => $screenreadertext_expand_toggle,
-    'collapse_toggle' => $screenreadertext_collapse_toggle,
-    'external_link' => $screenreadertext_external_link,
-    'target_blank' => $screenreadertext_target_blank,
+    'expand'          => get_default_localization( 'Open child menu' ),
+    'collapse'        => get_default_localization( 'Close child menu' ),
+    'expand_for'      => get_default_localization( 'Open child menu for' ),
+    'collapse_for'    => get_default_localization( 'Close child menu for' ),
+    'expand_toggle'   => get_default_localization( 'Open main menu' ),
+    'collapse_toggle' => get_default_localization( 'Close main menu' ),
+    'external_link'   => get_default_localization( 'External site:' ),
+    'target_blank'    => get_default_localization( 'opens in a new window' ),
   ) );
 } // end air_light_scripts
 

--- a/inc/includes.php
+++ b/inc/includes.php
@@ -4,8 +4,8 @@
  *
  * @Author: Niku Hietanen
  * @Date: 2020-02-18 15:07:17
- * @Last Modified by: Niku Hietanen
- * @Last Modified time: 2020-03-02 10:52:23
+ * @Last Modified by:   Timi Wahalahti
+ * @Last Modified time: 2020-11-19 10:05:54
  * @package air-light
  */
 
@@ -13,6 +13,9 @@ namespace Air_Light;
 
 // Theme setup
 require get_theme_file_path( '/inc/includes/theme-setup.php' );
+
+// Localized strings
+require get_theme_file_path( '/inc/includes/localization.php' );
 
 // Nav Walker
 require get_theme_file_path( '/inc/includes/nav-walker.php' );

--- a/inc/includes/localization.php
+++ b/inc/includes/localization.php
@@ -2,40 +2,79 @@
 /**
  * @Author: Timi Wahalahti
  * @Date:   2019-12-03 11:03:31
- * @Last Modified by:   Roni Laukkarinen
- * @Last Modified time: 2020-10-14 17:20:46
+ * @Last Modified by:   Timi Wahalahti
+ * @Last Modified time: 2020-11-19 11:23:46
  *
  * @package air-light
  */
 
-add_filter( 'air_helper_pll_register_strings', function() { // phpcs:ignore
-  return array(
-    // Air defaults for screen readers
-    'Accessibility: Open main menu' => 'Open main menu',
-    'Accessibility: Main navigation' => 'Main navigation',
-    'Accessibility: Back to top' => 'Back to top',
-    'Accessibility: Open child menu' => 'Open child menu',
-    'Accessibility: Close child menu' => 'Close child menu',
-    'Accessibility: Skip to content' => 'Skip to content',
-    'Accessibility: External site:' => 'External site:',
-    'Accessibility: opens in a new window' => 'opens in a new window',
+namespace Air_Light;
 
-    // Air defaults for screen readers in Finnish
-    'Saavutettavuus: -etusivulle' => '-etusivulle',
-    'Saavutettavuus: Siirry' => 'Siirry',
-    'Saavutettavuus: Siirry sivustolle' => 'Siirry sivustolle',
-    'Saavutettavuus: Päävalikko' => 'Päävalikko',
-    'Saavutettavuus: Selaa pääsivuja' => 'Selaa pääsivuja',
-    'Saavutettavuus: Alavalikko' => 'Alavalikko',
-    'Saavutettavuus: Valitse kieli:' => 'Valitse kieli:',
-    'Saavutettavuus: Olet tässä:' => 'Olet tässä:',
-    'Saavutettavuus: Alasivut:' => 'Alasivut:',
-    'Saavutettavuus: Hyppää sisältöön' => 'Hyppää sisältöön',
-    'Saavutettavuus: Avaa alavalikko' => 'Avaa alavalikko',
-    'Saavutettavuus: Avaa päävalikko' => 'Avaa päävalikko',
-    'Saavutettavuus: Sulje alavalikko' => 'Sulje alavalikko',
-    'Saavutettavuus: Sulje päävalikko' => 'Sulje päävalikko',
-    'Saavutettavuus: Ulkoinen sivusto:' => 'Ulkoinen sivusto:',
-    'Saavutettavuus: avautuu uuteen ikkunaan' => 'avautuu uuteen ikkunaan',
-  );
+add_filter( 'air_helper_pll_register_strings', function() { // phpcs:ignore
+  $strings = [
+    // 'Key: String' => 'String',
+  ];
+
+  /**
+   * Uncomment if you need to have default air-light accessibility strings
+   * translatable via Polylang string translations. By default these
+   * translations do come from theme translation files.
+   */
+  // foreach ( get_default_localization_strings() as $key => $value ) {
+  // $strings[ "Accessibility: {$key}" ] = $value;
+  // }
+
+  return $strings;
 } );
+
+function get_default_localization_strings( $language = 'en' ) {
+  $strings = [
+    'en'  => [
+      'Open main menu'        => __( 'Open main menu', 'air-light' ),
+      'Close main menu'       => __( 'Close main menu', 'air-light' ),
+      'Main navigation'       => __( 'Main navigation', 'air-light' ),
+      'Back to top'           => __( 'Back to top', 'air-light' ),
+      'Open child menu'       => __( 'Open child menu', 'air-light' ),
+      'Open child menu for'   => __( 'Open child menu for', 'air-light' ),
+      'Close child menu'      => __( 'Close child menu', 'air-light' ),
+      'Close child menu for'  => __( 'Close child menu for', 'air-light' ),
+      'Skip to content'       => __( 'Skip to content', 'air-light' ),
+      'External site:'        => __( 'External site:', 'air-light' ),
+      'opens in a new window' => __( 'opens in a new window', 'air-light' ),
+    ],
+    'fi'  => [
+      'Open main menu'        => 'Avaa päävalikko',
+      'Close main menu'       => 'Sulje päävalikko',
+      'Main navigation'       => 'Päävalikko',
+      'Back to top'           => 'Takaisin ylös',
+      'Open child menu'       => 'Avaa alavalikko',
+      'Open child menu for'   => 'Avaa alavalikko kohteelle',
+      'Close child menu'      => 'Sulje alavalikko',
+      'Close child menu for'  => 'Sulje alavalikko kohteelle',
+      'Skip to content'       => 'Takaisin ylös',
+      'External site:'        => 'Ulkoinen sivusto:',
+      'opens in a new window' => 'avautuu uuteen ikkunaan',
+    ],
+  ];
+
+  return ( array_key_exists( $language, $strings ) ) ? $strings[ $language ] : $strings['en'];
+} // end get_default_localization_strings
+
+function get_default_localization( $string ) {
+  if ( function_exists( 'ask__' ) && array_key_exists( "Accessibility: {$string}", apply_filters( 'air_helper_pll_register_strings', [] ) ) ) {
+    return ask__( "Accessibility: {$string}" );
+  }
+
+  return esc_html( get_default_localization_translation( $string ) );
+} // end get_default_localization
+
+function get_default_localization_translation( $string ) {
+  $language = get_bloginfo( 'language' );
+  if ( function_exists( 'pll_the_languages' ) ) {
+    $language = pll_current_language();
+  }
+
+  $translations = get_default_localization_strings( $language );
+
+  return ( array_key_exists( $string, $translations ) ) ? $translations[ $string ] : '';
+} // end get_default_localization_translation

--- a/inc/includes/localization.php
+++ b/inc/includes/localization.php
@@ -3,7 +3,7 @@
  * @Author: Timi Wahalahti
  * @Date:   2019-12-03 11:03:31
  * @Last Modified by:   Timi Wahalahti
- * @Last Modified time: 2020-11-19 11:23:46
+ * @Last Modified time: 2020-11-19 11:35:56
  *
  * @package air-light
  */
@@ -17,8 +17,7 @@ add_filter( 'air_helper_pll_register_strings', function() { // phpcs:ignore
 
   /**
    * Uncomment if you need to have default air-light accessibility strings
-   * translatable via Polylang string translations. By default these
-   * translations do come from theme translation files.
+   * translatable via Polylang string translations.
    */
   // foreach ( get_default_localization_strings() as $key => $value ) {
   // $strings[ "Accessibility: {$key}" ] = $value;

--- a/inc/includes/nav-walker.php
+++ b/inc/includes/nav-walker.php
@@ -9,8 +9,8 @@
  * License URI: http://www.gnu.org/licenses/gpl-2.0.txt
  *
  * @Date:   2019-10-15 12:30:02
- * @Last Modified by:   Roni Laukkarinen
- * @Last Modified time: 2019-12-30 21:58:07
+ * @Last Modified by:   Timi Wahalahti
+ * @Last Modified time: 2020-11-19 10:01:08
  *
  * @package air-light
  */
@@ -24,11 +24,6 @@ class Nav_Walker extends \Walker_Nav_Menu {
 
   public function start_lvl( &$output, $depth = 0, $args = array() ) {
     $indent = str_repeat( "\t", $depth );
-
-    // Get the ico
-    ob_start();
-    require get_theme_file_path( 'svg/chevron-down-main-nav.svg' );
-    $icon = ob_get_clean();
 
     // Reminder for translated accessible labels
     if ( function_exists( 'pll_the_languages' ) && function_exists( 'ask_e' ) ) {
@@ -44,6 +39,11 @@ class Nav_Walker extends \Walker_Nav_Menu {
         $screenreadertext = esc_html__( 'Open child menu', 'air-light' );
       }
     }
+
+    // Get the ico
+    ob_start();
+    require get_theme_file_path( 'svg/chevron-down-main-nav.svg' );
+    $icon = ob_get_clean();
 
     $output .= '<button class="dropdown-toggle" aria-expanded="false" aria-label="' . $screenreadertext . '">';
     $output .= $icon . '</button>';

--- a/inc/includes/nav-walker.php
+++ b/inc/includes/nav-walker.php
@@ -10,7 +10,7 @@
  *
  * @Date:   2019-10-15 12:30:02
  * @Last Modified by:   Timi Wahalahti
- * @Last Modified time: 2020-11-19 10:01:08
+ * @Last Modified time: 2020-11-19 11:24:38
  *
  * @package air-light
  */
@@ -25,27 +25,12 @@ class Nav_Walker extends \Walker_Nav_Menu {
   public function start_lvl( &$output, $depth = 0, $args = array() ) {
     $indent = str_repeat( "\t", $depth );
 
-    // Reminder for translated accessible labels
-    if ( function_exists( 'pll_the_languages' ) && function_exists( 'ask_e' ) ) {
-      if ( 'fi' === pll_current_language() ) {
-        $screenreadertext = ask__( 'Saavutettavuus: Avaa alavalikko' );
-      } else {
-        $screenreadertext = ask__( 'Accessibility: Open child menu' );
-      }
-    } else {
-      if ( 'fi' === get_bloginfo( 'language' ) ) {
-        $screenreadertext = esc_html__( 'Avaa alavalikko', 'air-light' );
-      } else {
-        $screenreadertext = esc_html__( 'Open child menu', 'air-light' );
-      }
-    }
-
     // Get the ico
     ob_start();
     require get_theme_file_path( 'svg/chevron-down-main-nav.svg' );
     $icon = ob_get_clean();
 
-    $output .= '<button class="dropdown-toggle" aria-expanded="false" aria-label="' . $screenreadertext . '">';
+    $output .= '<button class="dropdown-toggle" aria-expanded="false" aria-label="' . get_default_localization( 'Open child menu' ) . '">';
     $output .= $icon . '</button>';
     $output .= "\n$indent<ul class=\"sub-menu\">\n";
   }

--- a/template-parts/header/navigation.php
+++ b/template-parts/header/navigation.php
@@ -4,26 +4,30 @@
  *
  * @Author: Roni Laukkarinen
  * @Date: 2020-05-11 13:22:26
- * @Last Modified by:   Roni Laukkarinen
- * @Last Modified time: 2020-08-11 15:04:17
+ * @Last Modified by:   Timi Wahalahti
+ * @Last Modified time: 2020-11-19 10:02:09
  *
  * @package air-light
  */
 
 namespace Air_Light;
 
-// Accessible labels
+// Reminder for translated accessible labels
 if ( function_exists( 'pll_the_languages' ) && function_exists( 'ask_e' ) ) {
   if ( 'fi' === pll_current_language() ) {
     $screenreadertext_expand_toggle = ask__( 'Saavutettavuus: Avaa päävalikko' );
+    $nav_label = ask__( 'Saavutettavuus: Päävalikko' );
   } else {
     $screenreadertext_expand_toggle = ask__( 'Accessibility: Open main menu' );
+    $nav_label = ask__( 'Accessibility: Main navigation' );
   }
 } else {
   if ( 'fi' === get_bloginfo( 'language' ) ) {
     $screenreadertext_expand_toggle = esc_html__( 'Avaa päävalikko', 'air-light' );
+    $nav_label = esc_html( 'Päävalikko' );
   } else {
     $screenreadertext_expand_toggle = esc_html__( 'Open main menu', 'air-light' );
+    $nav_label = esc_html( 'Accessibility: Main navigation' );
   }
 }
 ?>
@@ -40,33 +44,17 @@ if ( function_exists( 'pll_the_languages' ) && function_exists( 'ask_e' ) ) {
 
   <nav id="nav" class="nav-primary">
 
-    <?php
-      if ( function_exists( 'pll_the_languages' ) && function_exists( 'ask_e' ) ) {
-        if ( 'fi' === pll_current_language() ) {
-          $nav_label = ask__( 'Saavutettavuus: Päävalikko' );
-        } else {
-          $nav_label = ask__( 'Accessibility: Main navigation' );
-        }
-      } else {
-        if ( 'fi' === get_bloginfo( 'language' ) ) {
-          $nav_label = esc_html( 'Päävalikko' );
-        } else {
-          $nav_label = esc_html( 'Accessibility: Main navigation' );
-        }
-      }
-
-      wp_nav_menu( array(
-        'theme_location' => 'primary',
-        'container'      => false,
-        'depth'          => 4,
-        'menu_class'     => 'menu-items',
-        'menu_id'        => 'main-menu',
-        'echo'           => true,
-        'fallback_cb'    => __NAMESPACE__ . '\Nav_Walker::fallback',
-        'items_wrap'     => '<ul role="menu" aria-label="' . $nav_label . '" id="%1$s" class="%2$s">%3$s</ul>',
-        'walker'         => new Nav_Walker(),
-      ) );
-      ?>
+    <?php wp_nav_menu( array(
+      'theme_location' => 'primary',
+      'container'      => false,
+      'depth'          => 4,
+      'menu_class'     => 'menu-items',
+      'menu_id'        => 'main-menu',
+      'echo'           => true,
+      'fallback_cb'    => __NAMESPACE__ . '\Nav_Walker::fallback',
+      'items_wrap'     => '<ul role="menu" aria-label="' . $nav_label . '" id="%1$s" class="%2$s">%3$s</ul>',
+      'walker'         => new Nav_Walker(),
+    ) ); ?>
 
   </nav><!-- #nav -->
 </div>

--- a/template-parts/header/navigation.php
+++ b/template-parts/header/navigation.php
@@ -5,31 +5,13 @@
  * @Author: Roni Laukkarinen
  * @Date: 2020-05-11 13:22:26
  * @Last Modified by:   Timi Wahalahti
- * @Last Modified time: 2020-11-19 10:02:09
+ * @Last Modified time: 2020-11-19 11:24:23
  *
  * @package air-light
  */
 
 namespace Air_Light;
 
-// Reminder for translated accessible labels
-if ( function_exists( 'pll_the_languages' ) && function_exists( 'ask_e' ) ) {
-  if ( 'fi' === pll_current_language() ) {
-    $screenreadertext_expand_toggle = ask__( 'Saavutettavuus: Avaa päävalikko' );
-    $nav_label = ask__( 'Saavutettavuus: Päävalikko' );
-  } else {
-    $screenreadertext_expand_toggle = ask__( 'Accessibility: Open main menu' );
-    $nav_label = ask__( 'Accessibility: Main navigation' );
-  }
-} else {
-  if ( 'fi' === get_bloginfo( 'language' ) ) {
-    $screenreadertext_expand_toggle = esc_html__( 'Avaa päävalikko', 'air-light' );
-    $nav_label = esc_html( 'Päävalikko' );
-  } else {
-    $screenreadertext_expand_toggle = esc_html__( 'Open main menu', 'air-light' );
-    $nav_label = esc_html( 'Accessibility: Main navigation' );
-  }
-}
 ?>
 
 <div class="main-navigation-wrapper" id="main-navigation-wrapper">
@@ -39,7 +21,7 @@ if ( function_exists( 'pll_the_languages' ) && function_exists( 'ask_e' ) ) {
     <span class="hamburger-box">
       <span class="hamburger-inner"></span>
     </span>
-    <span id="nav-toggle-label" class="nav-toggle-label"><?php echo esc_html( $screenreadertext_expand_toggle ); ?></span>
+    <span id="nav-toggle-label" class="nav-toggle-label"><?php echo esc_html( get_default_localization( 'Open main menu' ) ); ?></span>
   </button>
 
   <nav id="nav" class="nav-primary">
@@ -52,7 +34,7 @@ if ( function_exists( 'pll_the_languages' ) && function_exists( 'ask_e' ) ) {
       'menu_id'        => 'main-menu',
       'echo'           => true,
       'fallback_cb'    => __NAMESPACE__ . '\Nav_Walker::fallback',
-      'items_wrap'     => '<ul role="menu" aria-label="' . $nav_label . '" id="%1$s" class="%2$s">%3$s</ul>',
+      'items_wrap'     => '<ul role="menu" aria-label="' . get_default_localization( 'Main navigation' ) . '" id="%1$s" class="%2$s">%3$s</ul>',
       'walker'         => new Nav_Walker(),
     ) ); ?>
 


### PR DESCRIPTION
Previously accessibility translations were in the middle of HTML, logic was messy and different in each template part.

A new way of using default accessibility string translations is pretty straightforward: use `get_default_localization( 'My string' )` in the template part, add the original English string and Finnish translation to `inc/includes/localization.php` file and enjoy the ride.

By default theme will always use strings defined in that file inside function `get_default_localization_strings`. If there's need (for example having other languages) to have those translatable via Polylang string translations functionality, simply uncomment few lines on the same file and strings are added to Polylang.

This makes the default accessibility strings much easier to handle. And does not unnecessarily add those to Polylang if we're happy with default translations.