### PR TITLE
No default_featured_image by default, improvements to hero

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -6,8 +6,8 @@
  * own files under /inc and just require here.
  *
  * @Date: 2019-10-15 12:30:02
- * @Last Modified by: Niku Hietanen
- * @Last Modified time: 2021-01-12 15:28:58
+ * @Last Modified by:   Timi Wahalahti
+ * @Last Modified time: 2021-02-23 13:40:37
  *
  * @package air-light
  */
@@ -37,7 +37,7 @@ $theme_settings = [
   /**
    * Logo and featured image
    */
-  'default_featured_image' => get_theme_file_uri( 'images/default.jpg' ),
+  'default_featured_image' => null,
   'logo' => '/svg/logo.svg',
 
   /**

--- a/template-parts/hero.php
+++ b/template-parts/hero.php
@@ -7,18 +7,22 @@
  *
  * @Date:   2019-10-15 12:30:02
  * @Last Modified by:   Timi Wahalahti
- * @Last Modified time: 2021-01-12 16:00:20
+ * @Last Modified time: 2021-02-23 13:43:29
  * @package air-light
  */
 
 // Block settings
-$block_class = is_front_page() ? ' block-hero-front' : ' block-hero-' . get_post_type();
+$block_classes[] = is_front_page() ? ' block-hero-front' : ' block-hero-' . get_post_type();
 
 // Featured image
 $featured_image = has_post_thumbnail() ? wp_get_attachment_url( get_post_thumbnail_id() ) : THEME_SETTINGS['default_featured_image'];
 ?>
 
-<section class="block block-hero<?php echo esc_attr( $block_class ); ?>" style="background-image: url('<?php echo esc_url( $featured_image ); ?>');">
+<section class="block block-hero<?php echo esc_attr( implode( ' ', $block_classes ) ); ?>"
+  <?php if ( ! empty( $featured_image ) ) : ?>
+    style="background-image: url('<?php echo esc_url( $featured_image ); ?>');"
+  <?php endif; ?>
+>
   <div class="shade" aria-hidden="true"></div>
 
   <!-- <div class="container">

--- a/template-parts/hero.php
+++ b/template-parts/hero.php
@@ -7,7 +7,7 @@
  *
  * @Date:   2019-10-15 12:30:02
  * @Last Modified by:   Timi Wahalahti
- * @Last Modified time: 2021-02-23 13:43:29
+ * @Last Modified time: 2021-02-23 13:59:45
  * @package air-light
  */
 
@@ -18,7 +18,7 @@ $block_classes[] = is_front_page() ? ' block-hero-front' : ' block-hero-' . get_
 $featured_image = has_post_thumbnail() ? wp_get_attachment_url( get_post_thumbnail_id() ) : THEME_SETTINGS['default_featured_image'];
 ?>
 
-<section class="block block-hero<?php echo esc_attr( implode( ' ', $block_classes ) ); ?>"
+<section class="block block-hero <?php echo esc_attr( implode( ' ', $block_classes ) ); ?>"
   <?php if ( ! empty( $featured_image ) ) : ?>
     style="background-image: url('<?php echo esc_url( $featured_image ); ?>');"
   <?php endif; ?>


### PR DESCRIPTION
Empties the theme setting `default_featured_image` and checks the existence of the featured image before outputting background-image property in a hero. Also changes the additional classes into an array, for easier modification and development.

See #72 