### PR TITLE
Add themeDir to all asset file paths/names to match devpackages

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -1,3 +1,5 @@
+const themeDir = './';
+
 module.exports = {
   cleancss: {
     opts: {
@@ -32,7 +34,7 @@ module.exports = {
   },
   browsersync: {
     // Important! If src is wrong, styles will not inject to the browser
-    src: ['css/**/*'],
+    src: [themeDir + 'css/**/*'],
     opts: {
       logLevel: 'debug',
       injectChanges: true,
@@ -42,21 +44,21 @@ module.exports = {
       notify: true,
       // Generate with: mkdir -p /var/www/certs && cd /var/www/certs && mkcert localhost 192.168.x.xxx ::1
       https: {
-        key: "/var/www/certs/localhost+2-key.pem",
-        cert: "/var/www/certs/localhost+2.pem",
+        key: "/var/www/certs/localhost-key.pem",
+        cert: "/var/www/certs/localhost.pem",
       }
     },
     watch: [
-      '**/*.php',
-      'js/src/**/*.js'
+      themeDir + '**/*.php',
+      themeDir + 'js/src/**/*.js'
     ]
   },
   styles: {
-    gutenberg: 'sass/base/gutenberg.scss',
-    src: 'sass/**/*.{sass,scss}',
-    watch: 'sass/**/*.{sass,scss}',
-    development: 'css/dev',
-    production: 'css/prod',
+    gutenberg: themeDir + 'sass/base/gutenberg.scss',
+    src: themeDir + 'sass/*.scss',
+    watch: themeDir + 'sass/**/*.{sass,scss}',
+    development: themeDir + 'css/dev/',
+    production: themeDir + 'css/prod/',
     stylelint: {
       opts: {
         fix: false,
@@ -75,31 +77,31 @@ module.exports = {
         outputStyle: 'expanded',
         debugInfo: true,
         errLogToConsole: true,
-        includePaths: ['node_modules/']
+        includePaths: [themeDir + 'node_modules/']
       },
       production: {
         bundleExec: true,
         outputStyle: 'compressed',
         debugInfo: true,
         errLogToConsole: true,
-        includePaths: ['node_modules/']
+        includePaths: [themeDir + 'node_modules/']
       }
     }
   },
   js: {
-    src: 'js/src/*.js',
-    watch: 'js/src/**/*',
-    production: 'js/prod/',
-    development: 'js/dev/',
+    src: themeDir + 'js/src/*.js',
+    watch: themeDir + 'js/src/**/*',
+    production: themeDir + 'js/prod/',
+    development: themeDir + 'js/dev/',
   },
   php: {
     src: '**/*.php'
   },
   phpcs: {
-    src: ['**/*.php', '!' + 'node_modules/**/*'],
+    src: [themeDir + '**/*.php', '!' + themeDir + 'node_modules/**/*'],
     opts: {
       bin: '/usr/local/bin/phpcs',
-      standard: 'phpcs.xml',
+      standard: themeDir + 'phpcs.xml',
       warningSeverity: 0
     }
   }


### PR DESCRIPTION
This will make moving new gulp configs to devpackages a lot easier and lot less error prone.