### PR TITLE
Wrap theme settings to after_setup_theme action, fix filter name

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -6,8 +6,8 @@
  * own files under /inc and just require here.
  *
  * @Date: 2019-10-15 12:30:02
- * @Last Modified by: Niku Hietanen
- * @Last Modified time: 2021-05-19 08:37:57
+ * @Last Modified by:   Timi Wahalahti
+ * @Last Modified time: 2021-05-20 11:15:39
  *
  * @package air-light
  */
@@ -25,136 +25,138 @@ define( 'AIR_LIGHT_VERSION', '7.4.4' );
 /**
  * Theme settings
  */
-$theme_settings = [
-  /**
-   * Image and content sizes
-   */
-  'image_sizes' => [
-    'small'   => 300,
-    'medium'  => 700,
-    'large'   => 1200,
-  ],
-  'content_width' => 800,
-
-  /**
-   * Logo and featured image
-   */
-  'default_featured_image' => null,
-  'logo' => '/svg/logo.svg',
-
-  /**
-   * Theme textdomain
-   */
-  'textdomain' => 'air-light',
-
-  /**
-   * Menu locations
-   */
-  'menu_locations' => [
-    'primary' => __( 'Primary Menu', 'air-light' ),
-  ],
-
-  /**
-   * Taxonomies
-   *
-   * See the instructions:
-   * https://github.com/digitoimistodude/air-light#custom-taxonomies
-   */
-  'taxonomies' => [
-    // 'your-taxonomy' => [
-    //   'name' => 'Your_Taxonomy',
-    //   'post_types' => [ 'post', 'page' ],
-    // ],
-  ],
-
-  /**
-   * Post types
-   *
-   * See the instructions:
-   * https://github.com/digitoimistodude/air-light#custom-post-types
-   */
-  'post_types' => [
-    // 'your-post-type' => 'Your_Post_Type',
-  ],
-
-  /**
-   * Gutenberg -related settings
-   */
-  // Register custom ACF Blocks
-  'acf_blocks' => [
-    // [
-    //   'name'          => 'block-file-slug',
-    //   'title'         => 'Block Visible Name',
-    //   'prevent_cache' => true // Default value false
-    // ],
-  ],
-
-  // Custom ACF block default settings
-  'acf_block_defaults' => [
-    'category'          => 'air-light',
-    'mode'              => 'auto',
-    'align'             => 'full',
-    'post_types'        => [
-      'page',
+add_action( 'after_setup_theme', function() {
+  $theme_settings = [
+    /**
+     * Image and content sizes
+     */
+    'image_sizes' => [
+      'small'   => 300,
+      'medium'  => 700,
+      'large'   => 1200,
     ],
-    'supports'          => [
-      'align' => false,
+    'content_width' => 800,
+
+    /**
+     * Logo and featured image
+     */
+    'default_featured_image' => null,
+    'logo' => '/svg/logo.svg',
+
+    /**
+     * Theme textdomain
+     */
+    'textdomain' => 'air-light',
+
+    /**
+     * Menu locations
+     */
+    'menu_locations' => [
+      'primary' => __( 'Primary Menu', 'air-light' ),
     ],
-    'render_callback'   => __NAMESPACE__ . '\render_acf_block',
-  ],
 
-  // Restrict to only selected blocks
-  // Set the value to 'all' to allow all blocks everywhere
- 'allowed_blocks' => [
-    'default' => [
+    /**
+     * Taxonomies
+     *
+     * See the instructions:
+     * https://github.com/digitoimistodude/air-light#custom-taxonomies
+     */
+    'taxonomies' => [
+      // 'your-taxonomy' => [
+      //   'name' => 'Your_Taxonomy',
+      //   'post_types' => [ 'post', 'page' ],
+      // ],
     ],
-    'post' => [
-      'core/archives',
-      'core/audio',
-      'core/buttons',
-      'core/categories',
-      'core/code',
-      'core/column',
-      'core/columns',
-      'core/coverImage',
-      'core/embed',
-      'core/file',
-      'core/freeform',
-      'core/gallery',
-      'core/heading',
-      'core/html',
-      'core/image',
-      'core/latestComments',
-      'core/latestPosts',
-      'core/list',
-      'core/more',
-      'core/nextpage',
-      'core/paragraph',
-      'core/preformatted',
-      'core/pullquote',
-      'core/quote',
-      'core/reusableBlock',
-      'core/separator',
-      'core/shortcode',
-      'core/spacer',
-      'core/subhead',
-      'core/table',
-      'core/textColumns',
-      'core/verse',
-      'core/video',
+
+    /**
+     * Post types
+     *
+     * See the instructions:
+     * https://github.com/digitoimistodude/air-light#custom-post-types
+     */
+    'post_types' => [
+      // 'your-post-type' => 'Your_Post_Type',
     ],
-  ],
 
-  // If you want to use classic editor somewhere, define it here
-  'use_classic_editor' => [],
+    /**
+     * Gutenberg -related settings
+     */
+    // Register custom ACF Blocks
+    'acf_blocks' => [
+      // [
+      //   'name'          => 'block-file-slug',
+      //   'title'         => 'Block Visible Name',
+      //   'prevent_cache' => true // Default value false
+      // ],
+    ],
 
-  // Add your own settings and use them wherever you need, for example THEME_SETTINGS['my_custom_setting']
-  'my_custom_setting' => true,
-];
+    // Custom ACF block default settings
+    'acf_block_defaults' => [
+      'category'          => 'air-light',
+      'mode'              => 'auto',
+      'align'             => 'full',
+      'post_types'        => [
+        'page',
+      ],
+      'supports'          => [
+        'align' => false,
+      ],
+      'render_callback'   => __NAMESPACE__ . '\render_acf_block',
+    ],
 
-$theme_settings = apply_filters( 'air_helper_theme_settings', $theme_settings );
+    // Restrict to only selected blocks
+    // Set the value to 'all' to allow all blocks everywhere
+   'allowed_blocks' => [
+      'default' => [
+      ],
+      'post' => [
+        'core/archives',
+        'core/audio',
+        'core/buttons',
+        'core/categories',
+        'core/code',
+        'core/column',
+        'core/columns',
+        'core/coverImage',
+        'core/embed',
+        'core/file',
+        'core/freeform',
+        'core/gallery',
+        'core/heading',
+        'core/html',
+        'core/image',
+        'core/latestComments',
+        'core/latestPosts',
+        'core/list',
+        'core/more',
+        'core/nextpage',
+        'core/paragraph',
+        'core/preformatted',
+        'core/pullquote',
+        'core/quote',
+        'core/reusableBlock',
+        'core/separator',
+        'core/shortcode',
+        'core/spacer',
+        'core/subhead',
+        'core/table',
+        'core/textColumns',
+        'core/verse',
+        'core/video',
+      ],
+    ],
 
-define( 'THEME_SETTINGS', $theme_settings );
+    // If you want to use classic editor somewhere, define it here
+    'use_classic_editor' => [],
+
+    // Add your own settings and use them wherever you need, for example THEME_SETTINGS['my_custom_setting']
+    'my_custom_setting' => true,
+  ];
+
+  $theme_settings = apply_filters( 'air_light_theme_settings', $theme_settings );
+
+  define( 'THEME_SETTINGS', $theme_settings );
+} ); // end action after_setup_theme
 
 /**
  * Required files


### PR DESCRIPTION
We hadn't had wrapped the theme settings to any action, which caused the `air_helper_theme_settings` filter to be actually unusable. This PR wraps the theme settings to the earliest reasonable action, `after_setup_theme` which allows plugins to change the theme settings when needed.

At the same time, fix the naming of the filter to be actually about theme not out separate helper plugin.