### PR TITLE
Automate acf block icon from svg file

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  *
  * @Date: 2019-10-15 12:30:02
  * @Last Modified by:   Timi Wahalahti
- * @Last Modified time: 2021-05-20 11:15:39
+ * @Last Modified time: 2021-05-20 16:03:24
  *
  * @package air-light
  */
@@ -84,11 +84,10 @@ add_action( 'after_setup_theme', function() {
     // Register custom ACF Blocks
     'acf_blocks' => [
       // [
-      //   'name'          => 'block-file-slug',
-      //   'title'         => 'Block Visible Name',
-      //   'prevent_cache' => true, // Default value false,
-      //   // Icon: https://iconic.app/box/
-      //   'icon' => '<svg width="24" height="24" fill="none" viewBox="0 0 24 24"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4.75 8L12 4.75 19.25 8 12 11.25 4.75 8zM4.75 16L12 19.25 19.25 16M19.25 8v8M4.75 8v8M12 11.5V19"/></svg>',
+      //   'name'           => 'block-file-slug',
+      //   'title'          => 'Block Visible Name',
+      //   'prevent_cache'  => false, // Defaults to false
+      //   'icon'           => 'heart', // Icon defaults to svg file inside svg/block-icons named after the block name, eg. svg/block-icons/block-file-slug.svg
       // ],
     ],
 

--- a/functions.php
+++ b/functions.php
@@ -86,8 +86,12 @@ add_action( 'after_setup_theme', function() {
       // [
       //   'name'           => 'block-file-slug',
       //   'title'          => 'Block Visible Name',
-      //   'prevent_cache'  => false, // Defaults to false
-      //   'icon'           => 'block', // Icon defaults to svg file inside svg/block-icons named after the block name, eg. svg/block-icons/block-file-slug.svg
+      //   'prevent_cache'  => false, // Defaults to false,
+      //   // Icon defaults to svg file inside svg/block-icons named after the block name,
+      //   // eg. svg/block-icons/block-file-slug.svg
+      //   //
+      //   // Icon setting defines the dashicon equivalent: https://developer.wordpress.org/resource/dashicons/#block-default
+      //   // 'icon'  => 'block-default',
       // ],
     ],
 

--- a/functions.php
+++ b/functions.php
@@ -86,6 +86,7 @@ add_action( 'after_setup_theme', function() {
       // [
       //   'name'           => 'block-file-slug',
       //   'title'          => 'Block Visible Name',
+      //   // You can safely remove lines below if you find no use for them
       //   'prevent_cache'  => false, // Defaults to false,
       //   // Icon defaults to svg file inside svg/block-icons named after the block name,
       //   // eg. svg/block-icons/block-file-slug.svg

--- a/functions.php
+++ b/functions.php
@@ -87,7 +87,7 @@ add_action( 'after_setup_theme', function() {
       //   'name'           => 'block-file-slug',
       //   'title'          => 'Block Visible Name',
       //   'prevent_cache'  => false, // Defaults to false
-      //   'icon'           => 'heart', // Icon defaults to svg file inside svg/block-icons named after the block name, eg. svg/block-icons/block-file-slug.svg
+      //   'icon'           => 'block', // Icon defaults to svg file inside svg/block-icons named after the block name, eg. svg/block-icons/block-file-slug.svg
       // ],
     ],
 

--- a/inc/hooks/acf-blocks.php
+++ b/inc/hooks/acf-blocks.php
@@ -2,8 +2,8 @@
 /**
  * @Author: Timi Wahalahti
  * @Date:   2021-05-11 14:34:14
- * @Last Modified by: Niku Hietanen
- * @Last Modified time: 2021-05-19 08:40:13
+ * @Last Modified by:   Timi Wahalahti
+ * @Last Modified time: 2021-05-20 15:50:05
  * @package air-light
  */
 
@@ -38,6 +38,15 @@ function acf_blocks_init() {
           'data' => $example_data[ $block['name'] ],
         ],
       ];
+    }
+
+    // Check if icon is set, otherwise try to load svg icon
+    if ( ! isset( $block['icon'] ) || empty( $block['icon'] ) ) {
+      $icon_path = get_theme_file_path( "svg/block-icons/{$block['name']}.svg" );
+      $icon_path = apply_filters( 'air_light_acf_block_icon', $icon_path, $block['name'], $block );
+      if ( file_exists( $icon_path ) ) {
+        $block['icon'] = file_get_contents( $icon_path );
+      }
     }
 
     acf_register_block_type( wp_parse_args( $block, THEME_SETTINGS['acf_block_defaults'] ) );

--- a/svg/block-icons/block-file-slug.svg
+++ b/svg/block-icons/block-file-slug.svg
@@ -1,0 +1,1 @@
+<svg style="fill: none !important;" width="24" height="24" fill="none" viewBox="0 0 24 24"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4.75 8L12 4.75 19.25 8 12 11.25 4.75 8zM4.75 16L12 19.25 19.25 16M19.25 8v8M4.75 8v8M12 11.5V19"/></svg>

--- a/svg/block-icons/block.svg
+++ b/svg/block-icons/block.svg
@@ -1,1 +1,0 @@
-<svg width="24" height="24" fill="none" viewBox="0 0 24 24"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4.75 8L12 4.75 19.25 8 12 11.25 4.75 8zM4.75 16L12 19.25 19.25 16M19.25 8v8M4.75 8v8M12 11.5V19"/></svg>

--- a/svg/block-icons/block.svg
+++ b/svg/block-icons/block.svg
@@ -1,0 +1,1 @@
+<svg width="24" height="24" fill="none" viewBox="0 0 24 24"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4.75 8L12 4.75 19.25 8 12 11.25 4.75 8zM4.75 16L12 19.25 19.25 16M19.25 8v8M4.75 8v8M12 11.5V19"/></svg>


### PR DESCRIPTION
By default ACF blocks default to some lego looking icon. You can override it and use [dashicons](https://developer.wordpress.org/resource/dashicons/), but most likely that icon package does not contain suitable icons. There's also an option to override the block icon by feeding SVG string for the setting. Doing this in functions.php would cause a clutter on our main theme file, so instead of doing that let's automate the SVG icons for blocks.

Adding the SVG icon file named after the ACF block name, the theme will now try to load the icon from `svg/block-icons` directory. If no file exists, we will default back to lego looking icon.