### PR TITLE
Add custom setting groups support

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  *
  * @Date: 2019-10-15 12:30:02
  * @Last Modified by:   Timi Wahalahti
- * @Last Modified time: 2021-05-20 11:15:39
+ * @Last Modified time: 2021-05-20 18:19:49
  *
  * @package air-light
  */
@@ -28,6 +28,11 @@ define( 'AIR_LIGHT_VERSION', '7.4.5' );
 add_action( 'after_setup_theme', function() {
   $theme_settings = [
     /**
+     * Theme textdomain
+     */
+    'textdomain' => 'air-light',
+
+    /**
      * Image and content sizes
      */
     'image_sizes' => [
@@ -40,13 +45,17 @@ add_action( 'after_setup_theme', function() {
     /**
      * Logo and featured image
      */
-    'default_featured_image' => null,
-    'logo' => '/svg/logo.svg',
+    'default_featured_image'  => null,
+    'logo'                    => '/svg/logo.svg',
 
     /**
-     * Theme textdomain
+     * Custom setting group post ids when using Air Helper's custom setting
+     * feature and settings CPT. On multilingual sites using Polylang,
+     * translations are handled automatically.
      */
-    'textdomain' => 'air-light',
+    'custom_settings_post_ids' => [
+      // 'setting-group' => 0,
+    ],
 
     /**
      * Menu locations

--- a/inc/hooks.php
+++ b/inc/hooks.php
@@ -22,6 +22,7 @@ namespace Air_Light;
  */
 require get_theme_file_path( 'inc/hooks/general.php' );
 add_action( 'widgets_init', __NAMESPACE__ . '\widgets_init' );
+add_filter( 'air_helper_custom_settings_post_ids', __NAMESPACE__ . '\custom_settings_post_ids' );
 
 /**
  * Scripts and styles associated hooks

--- a/inc/hooks/general.php
+++ b/inc/hooks/general.php
@@ -4,8 +4,8 @@
  *
  * @Author: Niku Hietanen
  * @Date: 2020-02-20 13:46:50
- * @Last Modified by:   Roni Laukkarinen
- * @Last Modified time: 2021-05-04 11:12:20
+ * @Last Modified by:   Timi Wahalahti
+ * @Last Modified time: 2021-05-20 18:20:58
  *
  * @package air-light
  */
@@ -28,3 +28,14 @@ function widgets_init() {
     'after_title'   => '</h2>',
   ) );
 } // end widgets_init
+
+/**
+ * Register custom setting group post ids for Air Helper.
+ */
+function custom_settings_post_ids( $post_ids = [] ) {
+  if ( ! isset( THEME_SETTINGS['custom_settings_post_ids'] ) ) {
+    return $post_ids;
+  }
+
+  return wp_parse_args( THEME_SETTINGS['custom_settings_post_ids'], $post_ids );
+} // end custom_settings_post_ids


### PR DESCRIPTION
As we have planned to start using CPT for custom settings, as that is the easiest way to get translations for those, let's add some basic support for that in the theme.

In `functions.php` add a new theme setting `custom_settings_post_ids` where all custom setting groups are listed. In the array, the key is the setting group name and the value is the post id for the post in settings CPT. In `hooks/general.php` these are passed forward for Air Helper which is responsible for actually having the functionality to get settings.

Air Helper handles the multilingual part automatically if Polylang is installed, and uses the translation post id if one exists.

Related: https://github.com/digitoimistodude/air-helper/pull/36