### PR TITLE
Add social media accounts to theme settings

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  *
  * @Date: 2019-10-15 12:30:02
  * @Last Modified by:   Timi Wahalahti
- * @Last Modified time: 2021-05-20 11:15:39
+ * @Last Modified time: 2021-05-21 10:41:06
  *
  * @package air-light
  */
@@ -47,6 +47,13 @@ add_action( 'after_setup_theme', function() {
      * Theme textdomain
      */
     'textdomain' => 'air-light',
+
+    'social_media_accounts'  => [
+      // 'twitter' => [
+      //   'title' => 'Twitter',
+      //   'url'   => 'https://twitter.com/digitoimistodude',
+      // ],
+    ],
 
     /**
      * Menu locations


### PR DESCRIPTION
Typically social media account links/icons are shown in few places on the website. We have the base for this in Cacher, but let's make it a little more incorporated into our way of working by defining the different social media accounts in theme settings instead of their own array.

The Cacher snippet is already updated to work with networks coming from theme settings.