### PR TITLE
Simplify CPT and taxonomy registration by using the class name also as a slug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### [Unreleased]
 
 * Fix incorrect textdomain in external-link JS module
+* Simplify CPT and taxonomy registration by using the class name also as a slug
 
 ### 9.2.1: 2022-10-28
 

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Air-light can register your CPT:s automatically.
 
 ```
 'post_types' => [
-  'your-post-type' => 'Your_Post_Type'
+  'Your_Post_Type'
 ]
 ```
 
@@ -248,7 +248,7 @@ Air-light can register your Taxonomies automatically.
 1. Add your taxonomy to theme settings under taxonomies, located in `functions.php` like this:
 
 ```
-'your-taxonomy' => [
+[
   'name' => 'Your_Taxonomy'
   'post_types' => 'post, page'
 ]

--- a/README.md
+++ b/README.md
@@ -248,9 +248,8 @@ Air-light can register your Taxonomies automatically.
 1. Add your taxonomy to theme settings under taxonomies, located in `functions.php` like this:
 
 ```
-[
-  'name' => 'Your_Taxonomy'
-  'post_types' => 'post, page'
+'taxonomies' => [
+  'Your_Taxonomy' => [ 'post', 'page', 'your-post-type' ]
 ]
 ```
 

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  *
  * @Date: 2019-10-15 12:30:02
  * @Last Modified by:   Timi Wahalahti
- * @Last Modified time: 2022-11-03 16:06:07
+ * @Last Modified time: 2022-11-03 16:44:56
  *
  * @package air-light
  */
@@ -92,10 +92,7 @@ add_action( 'after_setup_theme', function() {
      * https://github.com/digitoimistodude/air-light#custom-taxonomies
      */
     'taxonomies' => [
-      // [
-      //   'name' => 'Your_Taxonomy',
-      //   'post_types' => [ 'post', 'page' ],
-      // ],
+      // 'Your_Taxonomy' => [ 'post', 'page' ],
     ],
 
     /**

--- a/functions.php
+++ b/functions.php
@@ -6,8 +6,8 @@
  * own files under /inc and just require here.
  *
  * @Date: 2019-10-15 12:30:02
- * @Last Modified by:   Roni Laukkarinen
- * @Last Modified time: 2022-10-28 10:17:27
+ * @Last Modified by:   Timi Wahalahti
+ * @Last Modified time: 2022-11-03 16:06:07
  *
  * @package air-light
  */
@@ -92,7 +92,7 @@ add_action( 'after_setup_theme', function() {
      * https://github.com/digitoimistodude/air-light#custom-taxonomies
      */
     'taxonomies' => [
-      // 'your-taxonomy' => [
+      // [
       //   'name' => 'Your_Taxonomy',
       //   'post_types' => [ 'post', 'page' ],
       // ],
@@ -105,7 +105,7 @@ add_action( 'after_setup_theme', function() {
      * https://github.com/digitoimistodude/air-light#custom-post-types
      */
     'post_types' => [
-      // 'your-post-type' => 'Your_Post_Type',
+      // 'Your_Post_Type',
     ],
 
     /**

--- a/inc/includes/theme-setup.php
+++ b/inc/includes/theme-setup.php
@@ -5,7 +5,7 @@
  * @Author: Timi Wahalahti
  * @Date: 2020-02-20 13:46:50
  * @Last Modified by:   Timi Wahalahti
- * @Last Modified time: 2022-11-03 16:10:59
+ * @Last Modified time: 2022-11-03 16:44:39
  *
  * @package vierityspalkki
  **/
@@ -45,10 +45,10 @@ function build_taxonomies() {
     return;
   }
 
-  foreach ( THEME_SETTINGS['taxonomies'] as $args ) {
-    $slug = strtolower( $args['name'] );
+  foreach ( THEME_SETTINGS['taxonomies'] as $name => $post_types ) {
+    $slug = strtolower( $name );
 
-    $classname = __NAMESPACE__ . '\\' . $args['name'];
+    $classname = __NAMESPACE__ . '\\' . $name;
     $file_path = get_theme_file_path( '/inc/taxonomies/' . str_replace('_', '-', $slug ) . '.php' );
 
     if ( ! file_exists( $file_path ) ) {
@@ -61,7 +61,7 @@ function build_taxonomies() {
     }
 
     $taxonomy_class = new $classname( $slug );
-    $taxonomy_class->register( $args['post_types'] );
+    $taxonomy_class->register( $post_types );
   }
 }
 

--- a/inc/includes/theme-setup.php
+++ b/inc/includes/theme-setup.php
@@ -2,12 +2,12 @@
 /**
  * Theme setup
  *
- * @Author: Niku Hietanen
+ * @Author: Timi Wahalahti
  * @Date: 2020-02-20 13:46:50
- * @Last Modified by:   Roni Laukkarinen
- * @Last Modified time: 2021-05-04 11:13:01
+ * @Last Modified by:   Timi Wahalahti
+ * @Last Modified time: 2022-11-03 16:10:59
  *
- * @package air-light
+ * @package vierityspalkki
  **/
 
 namespace Air_Light;
@@ -45,17 +45,19 @@ function build_taxonomies() {
     return;
   }
 
-  foreach ( THEME_SETTINGS['taxonomies'] as $slug => $args ) {
+  foreach ( THEME_SETTINGS['taxonomies'] as $args ) {
+    $slug = strtolower( $args['name'] );
+
     $classname = __NAMESPACE__ . '\\' . $args['name'];
-    $file_path = get_theme_file_path( '/inc/taxonomies/' . $slug . '.php' );
+    $file_path = get_theme_file_path( '/inc/taxonomies/' . str_replace('_', '-', $slug ) . '.php' );
 
     if ( ! file_exists( $file_path ) ) {
-      return new \WP_Error( 'invalid-taxonomy', __( 'The taxonomy class file does not exist.', 'air-light' ), $classname );
+      return new \WP_Error( 'invalid-taxonomy', __( 'The taxonomy class file does not exist.', 'vierityspalkki' ), $classname );
     }
     require $file_path;
 
     if ( ! class_exists( $classname ) ) {
-      return new \WP_Error( 'invalid-taxonomy', __( 'The taxonomy you attempting to create does not have a class to instance. Possible problems: your configuration does not match the class file name; the class file name does not exist.', 'air-light' ), $classname );
+      return new \WP_Error( 'invalid-taxonomy', __( 'The taxonomy you attempting to create does not have a class to instance. Possible problems: your configuration does not match the class file name; the class file name does not exist.', 'vierityspalkki' ), $classname );
     }
 
     $taxonomy_class = new $classname( $slug );
@@ -71,18 +73,20 @@ function build_post_types() {
     return;
   }
 
-  foreach ( THEME_SETTINGS['post_types'] as $slug => $name ) {
+  foreach ( THEME_SETTINGS['post_types'] as $name ) {
+    $slug = strtolower( $name );
+
     $classname = __NAMESPACE__ . '\\' . $name;
-    $file_path = get_theme_file_path( '/inc/post-types/' . $slug . '.php' );
+    $file_path = get_theme_file_path( '/inc/post-types/' . str_replace('_', '-', $slug ) . '.php' );
 
     if ( ! file_exists( $file_path ) ) {
-      return new \WP_Error( 'invalid-taxonomy', __( 'The taxonomy class file does not exist.', 'air-light' ), $classname );
+      return new \WP_Error( 'invalid-cpt', __( 'The custom post type class file does not exist.', 'vierityspalkki' ), $classname );
     }
     // Get the class file
     require $file_path;
 
     if ( ! class_exists( $classname ) ) {
-      return new \WP_Error( 'invalid-taxonomy', __( 'The taxonomy you attempting to create does not have a class to instance. Possible problems: your configuration does not match the class file name; the class file name does not exist.', 'air-light' ), $classname );
+      return new \WP_Error( 'invalid-cpt', __( 'The custom post type you attempting to create does not have a class to instance. Possible problems: your configuration does not match the class file name; the class file name does not exist.', 'vierityspalkki' ), $classname );
     }
 
     $post_type_class = new $classname( $slug );


### PR DESCRIPTION
We are doing some stupid extra work by defining the slug and class name individually when both are almost always the same.

In this PR, a change is made so that the class name gets used as a slug automatically. Slug is transformed to a lowercase version, and the underscore is changed to a dash for the file name.

This simplified the cpt & tax registration process.