### PR TITLE
For PHP8+: Remove deprecated stylelint rule and rename PHPCS rule

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -29,6 +29,7 @@ jobs:
       - name: Set up PHPCS and WordPress-Coding-Standards
         run: |
           composer global require --dev dealerdirect/phpcodesniffer-composer-installer
+          composer global config --no-plugins allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
           composer global require --dev phpcsstandards/phpcsextra:"^1.1.0"
           composer global require phpcsstandards/phpcsutils:"^1.0"
           composer global require --dev wp-coding-standards/wpcs:"^3.0"

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -18,26 +18,25 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - name: Checkout the repository
-      uses: actions/checkout@v3
+      - name: Checkout the repository
+        uses: actions/checkout@v3
 
-    - name: Setup PHP with Xdebug 2.x
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: '7.4'
-        coverage: xdebug2
+      - name: Setup PHP with Xdebug 2.x
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          coverage: xdebug2
 
-    - name: Set up PHPCS and WordPress-Coding-Standards
-      run: |
-        git clone -b master --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git $PHPCS_DIR
-        git clone -b 2.2.1 --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git $WPCS_DIR
-        $PHPCS_DIR/bin/phpcs --config-set installed_paths $WPCS_DIR,$PHPCOMPAT_DIR,$SNIFFS_DIR
-        git clone -b master --depth 1 https://github.com/wimg/PHPCompatibility.git $PHPCOMPAT_DIR
+      - name: Set up PHPCS and WordPress-Coding-Standards
+        run: |
+          git clone -b master --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git $PHPCS_DIR
+          git clone -b 3.0.1 --depth 1 https://github.com/WordPress/WordPress-Coding-Standards.git $WPCS_DIR
+          $PHPCS_DIR/bin/phpcs --config-set installed_paths $WPCS_DIR,$PHPCOMPAT_DIR,$SNIFFS_DIR
+          git clone -b master --depth 1 https://github.com/wimg/PHPCompatibility.git $PHPCOMPAT_DIR
 
-    - name: Run PHPCS
-      run: |
-        $PHPCS_DIR/bin/phpcs -p . --ignore=node_modules,*/css/*,*/sass/* --standard=phpcs.xml
+      - name: Run PHPCS
+        run: |
+          $PHPCS_DIR/bin/phpcs -p . --ignore=node_modules,*/css/*,*/sass/* --standard=phpcs.xml
 
-    - name: Test PHP for syntax errors
-      run: find -L . -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
-
+      - name: Test PHP for syntax errors
+        run: find -L . -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -7,7 +7,6 @@ name: PHP
 on: [push, pull_request]
 
 env:
-  PHPCS_DIR: /tmp/phpcs
   PHPCOMPAT_DIR: /tmp/phpcompatibility
   SNIFFS_DIR: /tmp/sniffs
   WPCS_DIR: /tmp/wpcs
@@ -24,19 +23,20 @@ jobs:
       - name: Setup PHP with Xdebug 2.x
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: '8.2'
           coverage: xdebug2
 
       - name: Set up PHPCS and WordPress-Coding-Standards
         run: |
-          git clone -b master --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git $PHPCS_DIR
-          git clone -b 3.0.1 --depth 1 https://github.com/WordPress/WordPress-Coding-Standards.git $WPCS_DIR
-          $PHPCS_DIR/bin/phpcs --config-set installed_paths $WPCS_DIR,$PHPCOMPAT_DIR,$SNIFFS_DIR
+          composer global require --dev dealerdirect/phpcodesniffer-composer-installer
+          composer global require --dev phpcsstandards/phpcsextra:"^1.1.0"
+          composer global require phpcsstandards/phpcsutils:"^1.0"
+          composer global require --dev wp-coding-standards/wpcs:"^3.0"
           git clone -b master --depth 1 https://github.com/wimg/PHPCompatibility.git $PHPCOMPAT_DIR
 
       - name: Run PHPCS
         run: |
-          $PHPCS_DIR/bin/phpcs -p . --ignore=node_modules,*/css/*,*/sass/* --standard=phpcs.xml
+          phpcs -p . --ignore=node_modules,*/css/*,*/sass/* --standard=phpcs.xml
 
       - name: Test PHP for syntax errors
         run: find -L . -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up PHPCS and WordPress-Coding-Standards
         run: |
           composer global require --dev dealerdirect/phpcodesniffer-composer-installer
-          composer global config --no-plugins allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
+          composer global config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
           composer global require --dev phpcsstandards/phpcsextra:"^1.1.0"
           composer global require phpcsstandards/phpcsutils:"^1.0"
           composer global require --dev wp-coding-standards/wpcs:"^3.0"

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -93,7 +93,6 @@
     "no-duplicate-selectors": true,
     "length-zero-no-unit": true,
     "font-weight-notation": "numeric",
-    "number-leading-zero": "never",
     "number-max-precision": 3,
     "selector-class-pattern": null,
     "selector-max-class": 4,

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -29,7 +29,7 @@
         <exclude name="Generic.WhiteSpace.ScopeIndent.IncorrectExact" />
         <exclude name="Generic.WhiteSpace.ScopeIndent.Incorrect" />
         <exclude name="Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed" />
-        <exclude name="WordPress.WhiteSpace.PrecisionAlignment" />
+        <exclude name="Universal.WhiteSpace.PrecisionAlignment" />
         <exclude name="PEAR.Functions.FunctionCallSignature.Indent" />
         <exclude name="WordPress.Arrays.ArrayIndentation.ItemNotAligned" />
         <exclude name="WordPress.Arrays.ArrayIndentation.MultiLineArrayItemNotAligned" />


### PR DESCRIPTION
* number-leading-zero rule was deprecated in Stylelint version 15.0.0 due to "pretty printing" features removed and focusing on linting itself. (Migrating to Prettier for SCSS linting?)
* WordPress.WhiteSpace.PrecisionAlignment has been replaced by Universal.WhiteSpace.PrecisionAlignment in 3.0.0 ([changelog entry](https://github.com/WordPress/WordPress-Coding-Standards/blob/7722c0b8a6f4eb615be4ba8ebe22ed92a5fa87d7/CHANGELOG.md?plain=1#L234))