### PR TITLE
Fixed PHP styling with new guidelines and fixed allowed blocks

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -137,8 +137,7 @@ add_action( 'after_setup_theme', function() {
     // Restrict to only selected blocks
     // Set the value to 'all' to allow all blocks everywhere
    'allowed_blocks' => [
-      'default' => [
-      ],
+      'default' => [],
       'post' => [
         'core/archives',
         'core/audio',

--- a/inc/hooks/gutenberg.php
+++ b/inc/hooks/gutenberg.php
@@ -25,6 +25,10 @@ function allowed_block_types( $allowed_blocks, $editor_context ) {
 
   // If there is post type specific blocks, add them to the allowed blocks list
   if ( isset( $editor_context->post->post_type ) && isset( THEME_SETTINGS['allowed_blocks'][ $editor_context->post->post_type ] ) ) {
+    if ( 'all' === THEME_SETTINGS['allowed_blocks'][ $editor_context->post->post_type ] ) {
+      return $allowed_blocks;
+    }
+
     $allowed_blocks = array_merge( $allowed_blocks, THEME_SETTINGS['allowed_blocks'][ $editor_context->post->post_type ] );
   }
 

--- a/inc/includes/nav-walker.php
+++ b/inc/includes/nav-walker.php
@@ -106,7 +106,6 @@ class Nav_Walker extends \Walker_Nav_Menu {
     } else {
       $output .= "\n{$n}{$indent}<ul>{$n}";
     }
-
   }
 
  	/**
@@ -146,7 +145,7 @@ class Nav_Walker extends \Walker_Nav_Menu {
 
     // Updating the CSS classes of a menu item in the WordPress Customizer preview results in all classes defined
 		// in that particular input box to come in as one big class string.
-		$split_on_spaces = function ( $class ) {
+		$split_on_spaces = function( $class ) {
 			return preg_split( '/\s+/', $class );
 		};
 		$classes         = $this->flatten( array_map( $split_on_spaces, $classes ) );
@@ -600,5 +599,4 @@ class Nav_Walker extends \Walker_Nav_Menu {
 			}
 			return $result;
 		}
-
 	}

--- a/inc/includes/post-type.php
+++ b/inc/includes/post-type.php
@@ -65,5 +65,4 @@ abstract class Post_Type {
 
     return register_post_type( $slug, $args );
   }
-
 }

--- a/inc/includes/taxonomy.php
+++ b/inc/includes/taxonomy.php
@@ -84,5 +84,4 @@ abstract class Taxonomy {
 
 		return $registered_object_types;
 	}
-
 }

--- a/inc/taxonomies/your-taxonomy.php
+++ b/inc/taxonomies/your-taxonomy.php
@@ -54,5 +54,4 @@ class Your_Taxonomy extends Taxonomy {
 
     $this->register_wp_taxonomy( $this->slug, $post_types, $args );
   }
-
 }

--- a/inc/template-tags/edit-link.php
+++ b/inc/template-tags/edit-link.php
@@ -28,5 +28,4 @@ function air_edit_link() {
       </a>
     </p>
   <?php
-
 }

--- a/inc/template-tags/single-comment.php
+++ b/inc/template-tags/single-comment.php
@@ -15,7 +15,8 @@
 
 namespace Air_Light;
 
-function single_comment( $comment, $args, $depth ) { ?>
+function single_comment( $comment, $args, $depth ) {
+?>
   <li id="li-comment-<?php comment_ID(); ?>" <?php comment_class(); ?>>
     <div id="comment-<?php comment_ID(); ?>">
       <?php echo get_avatar( $comment, '62' ); ?>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -29,11 +29,11 @@
         <exclude name="Generic.WhiteSpace.ScopeIndent.IncorrectExact" />
         <exclude name="Generic.WhiteSpace.ScopeIndent.Incorrect" />
         <exclude name="Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed" />
-        <exclude name="WordPress.WhiteSpace.PrecisionAlignment" />
+        <exclude name="Universal.WhiteSpace.PrecisionAlignment" />
         <exclude name="PEAR.Functions.FunctionCallSignature.Indent" />
         <exclude name="WordPress.Arrays.ArrayIndentation.ItemNotAligned" />
         <exclude name="WordPress.Arrays.ArrayIndentation.MultiLineArrayItemNotAligned" />
-        <exclude name="WordPress.WhiteSpace.DisallowInlineTabs.NonIndentTabsUsed" />
+        <exclude name="Universal.WhiteSpace.DisallowInlineTabs.NonIndentTabsUsed" />
         <exclude name="WordPress.Arrays.ArrayIndentation.CloseBraceNotAligned" />
         <exclude name="PEAR.Functions.FunctionCallSignature.OpeningIndent" />
 
@@ -58,7 +58,7 @@
         <exclude name="WordPress.Arrays.ArrayDeclarationSpacing.AssociativeArrayFound" />
         <exclude name="Squiz.ControlStructures.ControlSignature.NewlineAfterOpenBrace" />
         <exclude name="PHPCompatibility.PHP.NewFunctionArrayDereferencing.Found" />
-        <exclude name="Generic.Arrays.DisallowShortArraySyntax" />
+        <exclude name="Universal.Arrays.DisallowShortArraySyntax" />
 
         <!-- General WordPress stuff we like to overrule -->
         <exclude name="WordPress.Files.FileName.InvalidClassFileName" />
@@ -97,9 +97,10 @@
         <exclude name="WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned" />
         <exclude name="WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode" />
         <exclude name="WordPress.DB.SlowDBQuery.slow_db_query_tax_query" />
-        <exclude name="WordPress.PHP.DisallowShortTernary.Found" />
+        <exclude name="Universal.Operators.DisallowShortTernary.Found" />
         <exclude name="WordPress.DB.SlowDBQuery.slow_db_query_meta_query" />
-
+        <exclude name="Squiz.Functions.MultiLineFunctionDeclaration.SpaceAfterFunction" />
+        
         <!-- Project based -->
         <exclude name="Squiz.PHP.CommentedOutCode.Found" />
     </rule>


### PR DESCRIPTION
Fixed PHP styling to be aligned with the WordPress Styling Guidelines 3.0.0

Added possibility to allow all blocks to be used in a single post type (closes #176)