### PR TITLE
Pop!_OS support for newtheme script

### DIFF
--- a/bin/newtheme-popos.sh
+++ b/bin/newtheme-popos.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# WordPress theme starting bash script for Air-light, ported for Pop!_OS, might work on Ubuntu or even Debian, or other forks.
+# @Author: Roni Laukkarinen
+# @Date:   2021-04-22 08:06:02
+# @Last Modified by:   Roni Äikäs
+# @Last Modified time: 2023-09-29 22:15:53
+
+# Script specific vars
+SCRIPT_LABEL='for Pop!_OS'
+SCRIPT_VERSION='1.0.0 (2023-09-29)'
+
+# Vars needed for this file to function globally
+CURRENTFILE=`basename $0`
+
+# Determine scripts location to get imports right
+if [ "$CURRENTFILE" = "newtheme.sh" ]; then
+  SCRIPTS_LOCATION="$( pwd )"
+  source ${SCRIPTS_LOCATION}/tasks/variables.sh
+  source ${SCRIPTS_LOCATION}/tasks/header.sh
+  exit
+else
+  DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+  ORIGINAL_FILE=$( readlink $DIR/$CURRENTFILE )
+  SCRIPTS_LOCATION=$( dirname $ORIGINAL_FILE )
+fi
+
+# Final note about server requirements
+echo ""
+echo "${WHITE}Using this start script requires you use the following:
+https://github.com/raikasdev/popos-lemp-setup
+https://github.com/digitoimistodude/air-light
+${TXTRESET}"
+
+# First, let's check updates to self
+source ${SCRIPTS_LOCATION}/tasks/self-update.sh
+
+# Import required tasks
+source ${SCRIPTS_LOCATION}/tasks/imports.sh
+
+# Replace Air-light with your theme name and other seds
+source ${SCRIPTS_LOCATION}/tasks/replaces-wsl.sh
+
+# The end
+source ${SCRIPTS_LOCATION}/tasks/footer.sh

--- a/bin/newtheme-popos.sh
+++ b/bin/newtheme-popos.sh
@@ -27,7 +27,7 @@ fi
 # Final note about server requirements
 echo ""
 echo "${WHITE}Using this start script requires you use the following:
-https://github.com/raikasdev/popos-lemp-setup
+https://github.com/raikasdev/pop-lemp-setup
 https://github.com/digitoimistodude/air-light
 ${TXTRESET}"
 

--- a/bin/tasks/cleanups.sh
+++ b/bin/tasks/cleanups.sh
@@ -21,5 +21,4 @@ rm ${PROJECT_THEME_PATH}/sass/layout/_wordpress.scss
 echo "${YELLOW}Remove things we need to remove anyway in each start...${TXTRESET}"
 rm ${PROJECT_THEME_PATH}/sass/layout/_site-footer.scss
 touch ${PROJECT_THEME_PATH}/sass/layout/_site-footer.scss
-rm ${PROJECT_THEME_PATH}/template-parts/header/demo-content.php
 rm -rf ${PROJECT_THEME_PATH}/template-parts/footer

--- a/bin/tasks/replaces-wsl.sh
+++ b/bin/tasks/replaces-wsl.sh
@@ -22,9 +22,11 @@ read -p "${BOLDYELLOW}Do we use comments in this project? (y/n)${TXTRESET} " yn
 
 echo "${YELLOW}Running project gulp styles once...${TXTRESET}"
 cd ${PROJECT_PATH}
-gulp devstyles
-gulp prodstyles
+
+# NPX to try use the project gulp first (making sure we use right version)
+npx gulp devstyles
+npx gulp prodstyles
 
 echo "${YELLOW}Running project gulp scripts task once...${TXTRESET}"
 cd ${PROJECT_PATH}
-gulp js
+npx gulp js

--- a/functions.php
+++ b/functions.php
@@ -187,6 +187,11 @@ add_action( 'after_setup_theme', function() {
   $theme_settings = apply_filters( 'air_light_theme_settings', $theme_settings );
 
   define( 'THEME_SETTINGS', $theme_settings );
+
+  function mikroni() {
+  return 'mikroni.fi';
+}
+add_filter( 'air_helper_allow_user_to_domain', __NAMESPACE__ . '\mikroni' );
 } ); // end action after_setup_theme
 
 /**
@@ -199,3 +204,4 @@ require get_theme_file_path( '/inc/template-tags.php' );
 // Run theme setup
 add_action( 'after_setup_theme', __NAMESPACE__ . '\theme_setup' );
 add_action( 'after_setup_theme', __NAMESPACE__ . '\build_theme_support' );
+


### PR DESCRIPTION
Adds support for Pop!_OS. Ubuntu, Debian, Mint, Zorin, etc might work, but no guarantees.

See also: 
- [Pop!_OS LEMP setup instructions](https://github.com/raikasdev/pop-lemp-setup/tree/master)
- [Dudestack PR #16](https://github.com/digitoimistodude/dudestack/pull/16)