### PR TITLE
Add classicpress support

### DIFF
--- a/inc/includes/theme-setup.php
+++ b/inc/includes/theme-setup.php
@@ -129,11 +129,18 @@ function rebuild_post_types() {
  * Build theme support
  */
 function build_theme_support() {
+  global $cp_version;
+
   add_theme_support( 'automatic-feed-links' );
   add_theme_support( 'title-tag' );
   add_theme_support( 'post-thumbnails' );
   add_theme_support( 'align-wide' );
   add_theme_support( 'wp-block-styles' );
+
+  if ( isset( $cp_version ) ) {
+    return;
+  }
+
   add_theme_support(
     'html5',
     [


### PR DESCRIPTION
Great theme you made, here's my modest contribution;

This PR fixes a deprecation when using [classicpress](https://github.com/ClassicPress/ClassicPress) (a lighter wp without blocks)

```
Exception has occurred: Deprecated
Function add_theme_support( 'html5' ) was called with an argument that is <strong>deprecated</strong> since version CP-2.0.0! HTML5 is the default.
```
