### PR TITLE
Fix HTML/a11y workflow vnu.jar 404, Ref: DEV-986

### DIFF
--- a/.github/workflows/html.yml
+++ b/.github/workflows/html.yml
@@ -18,7 +18,9 @@ jobs:
         java-version: '17'
 
     - name: Download vnu.jar
-      run: wget https://github.com/validator/validator/releases/download/latest/vnu.jar
+      run: |
+        wget -q https://github.com/validator/validator/releases/download/20.6.30/vnu.jar_20.6.30.zip
+        unzip -j vnu.jar_20.6.30.zip "*/vnu.jar" -d .
 
     # Skipping this for now, see DEV-347
     #- name: Run vnu validator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-### [Unreleased]: 2026-04-21
+### [Unreleased]: 2026-05-07
 * Fix indentation: convert tabs to 2-space indent in several files, Ref: DEV-906
 * Add filter to disable remote block patterns, Ref: DEV-985
+* Fix HTML/a11y workflow vnu.jar download by pinning to release `20.6.30` and extracting from zip, Ref: DEV-986
 
 ### 10.1.1: 2026-04-08
 


### PR DESCRIPTION
## Summary

The `wget https://github.com/validator/validator/releases/download/latest/vnu.jar` step 404'd because:

1. GitHub does not resolve `latest` to the real tag for asset downloads
2. `validator/validator` does not publish a bare `vnu.jar` - the jar ships inside `vnu.jar_<version>.zip`

Pinned to the latest tagged release (`20.6.30`, June 2020 - upstream has not released since), download the zip and extract `vnu.jar` from it. The actual validator run remains commented out per DEV-347.

## Test plan
- [ ] Workflow run succeeds on push to this branch
